### PR TITLE
feat(schematic-analyzer): expose physical pin numbers from pstchip.dat in component query

### DIFF
--- a/skills/schematic-analyzer/scripts/analyzer.py
+++ b/skills/schematic-analyzer/scripts/analyzer.py
@@ -584,6 +584,7 @@ class SchematicAnalyzer:
 
         nets: list[dict[str, str]] = []
         seen_net_pairs: set[tuple[str, str]] = set()
+        comp_pin_map = phase_1["component_nets"].get(ref, {}).get("pin_number_map", {})
         for pin_number, net_name in sorted(phase_1["component_nets"].get(ref, {}).get("pins", {}).items()):
             if not include_full and str(net_name).startswith("unconnected-"):
                 continue
@@ -597,6 +598,10 @@ class SchematicAnalyzer:
                 "name": pair[0],
                 "pin": pair[1],
             }
+            # Add physical pin number from pstchip.dat
+            phys_pin = comp_pin_map.get(pin_name)
+            if phys_pin:
+                entry["pin_number"] = phys_pin
             # Annotate GPIO ball-name pins with their signal function
             if (
                 is_dat
@@ -1221,7 +1226,13 @@ class SchematicAnalyzer:
                 base = re.sub(r"#\w+$", "", e["pin"])
                 base_names.add(base)
             if len(base_names) == 1:
-                merged.append({"name": net_name, "pin": f"{base_names.pop()} ×{len(entries)}"})
+                base = base_names.pop()
+                result = {"name": net_name, "pin": f"{base} ×{len(entries)}"}
+                # Preserve pin_number if all entries share the same one
+                pin_nums = {e.get("pin_number") for e in entries if "pin_number" in e}
+                if len(pin_nums) == 1:
+                    result["pin_number"] = pin_nums.pop()
+                merged.append(result)
             else:
                 merged.extend(entries)
         return merged
@@ -1246,7 +1257,12 @@ class SchematicAnalyzer:
                 merged.append(entries[0])
             else:
                 pins = ",".join(e["pin"] for e in entries)
-                merged.append({"name": name, "pin": pins})
+                result: dict[str, str] = {"name": name, "pin": pins}
+                # Preserve pin_number as comma-separated if present
+                pin_nums = [e["pin_number"] for e in entries if "pin_number" in e]
+                if pin_nums:
+                    result["pin_number"] = ",".join(pin_nums)
+                merged.append(result)
         return merged
 
     def _pin_name(self, component, pin_number: str, dat_source: bool = False) -> str:

--- a/skills/schematic-analyzer/scripts/tools/cadence/connectivity.py
+++ b/skills/schematic-analyzer/scripts/tools/cadence/connectivity.py
@@ -14,7 +14,7 @@ from typing import Any, Optional
 from ..connectivity_builder import ConnectivityGraph, NetConnection
 from ..constants import DEFAULT_NET_TYPE
 from ..project_indexer import ProjectIndex
-from .netlist_dat_parser import find_netlist_dir, build_pin_net_map_from_dat, parse_pstxprt
+from .netlist_dat_parser import find_netlist_dir, build_pin_net_map_from_dat, parse_pstxprt, parse_pstchip
 from .xml_parser import CadenceXMLParser
 
 
@@ -73,10 +73,14 @@ class CadenceConnectivityBuilder:
 
         # Try to load page information from pstxprt.dat
         page_info: dict[str, dict] = {}
+        pin_number_map: dict[str, dict[str, str]] = {}  # PART_NAME -> {pin_func -> physical_pin}
         if source == "pstxnet.dat" and netlist_dir is not None:
             pstxprt_file = netlist_dir / "pstxprt.dat"
             if pstxprt_file.exists():
                 page_info = parse_pstxprt(pstxprt_file)
+            pstchip_file = netlist_dir / "pstchip.dat"
+            if pstchip_file.exists():
+                pin_number_map = parse_pstchip(pstchip_file)
 
         all_nets_data: dict[str, NetConnection] = {}
         component_nets: dict[str, dict] = {}
@@ -99,12 +103,20 @@ class CadenceConnectivityBuilder:
             if ref in page_info:
                 sheet_path = page_info[ref]["page"]
 
+            # Resolve physical pin numbers from pstchip.dat via PART_NAME
+            comp_pin_map: dict[str, str] = {}
+            if comp and pin_number_map:
+                part_name = self._extract_part_name(comp.lib_id)
+                if part_name and part_name in pin_number_map:
+                    comp_pin_map = pin_number_map[part_name]
+
             component_nets[ref] = {
                 "pins": dict(pin_nets),
                 "pin_count": len(pin_nets),
                 "reference": ref,
                 "sheet_path": sheet_path,
                 "dat_source": source == "pstxnet.dat",
+                "pin_number_map": comp_pin_map,
             }
 
         # Build all_nets: aggregate pins per net
@@ -131,3 +143,14 @@ class CadenceConnectivityBuilder:
             component_nets=component_nets,
             warnings=warnings,
         )
+
+    @staticmethod
+    def _extract_part_name(library_id: str) -> str:
+        """Extract PART_NAME from a Cadence library_id.
+
+        Cadence library_id format: ``LIB_NAME.OLB:PART_NAME``
+        e.g. ``RK_IC.OLB:PMIC_RK806S-5`` → ``PMIC_RK806S-5``
+        """
+        if ':' in library_id:
+            return library_id.split(':', 1)[1]
+        return library_id

--- a/skills/schematic-analyzer/scripts/tools/cadence/netlist_dat_parser.py
+++ b/skills/schematic-analyzer/scripts/tools/cadence/netlist_dat_parser.py
@@ -379,3 +379,101 @@ def build_pin_net_map_from_dat(netlist_dir: Path) -> dict[str, dict[str, str]]:
         return {}
 
     return parse_pstxnet(pstxnet_file)
+
+
+def parse_pstchip(file_path: Path) -> dict[str, dict[str, str]]:
+    r"""Parse Allegro pstchip.dat to extract pin-function-to-physical-pin mapping.
+
+    The pstchip.dat file defines library part primitives with pin sections that
+    map functional pin names (e.g. ``VOUT1``, ``NLDO1``) to physical pin numbers
+    via ``PIN_NUMBER='(...)'`` tuples.
+
+    PIN_NUMBER tuple formats:
+      - Simple: ``PIN_NUMBER='(1)'`` → physical pin 1
+      - Complex: ``PIN_NUMBER='(49,0,0)'`` → first non-zero element = pin 49
+      - Complex: ``PIN_NUMBER='(0,14,0)'`` → first non-zero element = pin 14
+
+    The result is indexed by ``PART_NAME`` so callers can look up a component's
+    pin map using the part name extracted from its library_id.
+
+    Args:
+        file_path: Path to pstchip.dat file.
+
+    Returns:
+        Dictionary mapping ``{PART_NAME: {pin_function_name: physical_pin_number}}``.
+        Pin function names have Cadence escape sequences (``\\X\\``) stripped.
+        Returns empty dict if file not found.
+    """
+    pin_map: dict[str, dict[str, str]] = {}
+
+    if not file_path.is_file():
+        return pin_map
+
+    content = file_path.read_text(encoding='utf-8', errors='ignore')
+    lines = content.split('\n')
+
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+
+        # Look for primitive block start: primitive 'NAME';
+        if line.startswith('primitive'):
+            prim_match = re.match(r"primitive\s+'([^']+)'", line)
+            if prim_match:
+                current_pins: dict[str, str] = {}
+                current_part_name: str | None = None
+                in_pin_section = False
+                i += 1
+
+                while i < len(lines):
+                    inner = lines[i].strip()
+
+                    if inner.startswith('end_primitive'):
+                        # Save if we have a PART_NAME
+                        if current_part_name and current_pins:
+                            pin_map[current_part_name] = current_pins
+                        break
+
+                    if inner == 'pin':
+                        in_pin_section = True
+                        i += 1
+                        continue
+
+                    if inner == 'end_pin':
+                        in_pin_section = False
+                        i += 1
+                        continue
+
+                    if in_pin_section:
+                        # Pin function name line: '\VOUT1\':
+                        # or for simple parts: '1':
+                        pin_name_match = re.match(r"'([^']+)'\s*:", inner)
+                        if pin_name_match:
+                            raw_pin_name = _clean_pin_escape(pin_name_match.group(1))
+                            # Look ahead for PIN_NUMBER on the next line
+                            if i + 1 < len(lines):
+                                next_line = lines[i + 1].strip()
+                                pn_match = re.search(r"PIN_NUMBER\s*=\s*'\(([^)]+)\)'", next_line)
+                                if pn_match:
+                                    tuple_str = pn_match.group(1)
+                                    # Extract first non-zero element as physical pin number
+                                    parts = tuple_str.split(',')
+                                    pin_num = ""
+                                    for p in parts:
+                                        p = p.strip()
+                                        if p and p != '0':
+                                            pin_num = p
+                                            break
+                                    if pin_num:
+                                        current_pins[raw_pin_name] = pin_num
+
+                    # Look for PART_NAME in body section
+                    if inner.startswith('PART_NAME'):
+                        pn_match = re.search(r"PART_NAME\s*=\s*'([^']+)'", inner)
+                        if pn_match:
+                            current_part_name = pn_match.group(1)
+
+                    i += 1
+        i += 1
+
+    return pin_map


### PR DESCRIPTION
## Summary
- Parse `pstchip.dat` to map pin function names (e.g. `VOUT1`) to physical pin numbers (e.g. pin 49) via new `parse_pstchip()` function
- Include `pin_number` field in `--component` query output for Cadence designs
- Preserve `pin_number` through net merging logic (both same-pin and multi-pin merges)

## Test plan
- [x] Verify `--component` query on a Cadence design with pstchip.dat shows `pin_number` fields
- [x] Confirm merged nets retain pin_number when all entries share the same physical pin
- [x] Verify graceful fallback when pstchip.dat is absent (no regression for non-Cadence designs)