### PR TITLE
fix(schematic-analyzer): add pin_number to net query results

### DIFF
--- a/skills/schematic-analyzer/scripts/analyzer.py
+++ b/skills/schematic-analyzer/scripts/analyzer.py
@@ -705,13 +705,18 @@ class SchematicAnalyzer:
             component_sheet_paths.add(sheet_path)
             if page_name not in pages:
                 pages.append(page_name)
-            is_dat = graph.component_nets.get(ref, {}).get("dat_source", False)
+            is_dat = comp_nets.get("dat_source", False)
             pin_nm = self._pin_name(component, pin_number, dat_source=is_dat)
             pin_entry: dict[str, str] = {
                 "ref": ref,
                 "pin": pin_nm,
                 "page": page_name,
             }
+            # Add physical pin number from pstchip.dat
+            comp_pin_map = comp_nets.get("pin_number_map", {})
+            phys_pin = comp_pin_map.get(pin_nm)
+            if phys_pin:
+                pin_entry["pin_number"] = phys_pin
             if (
                 is_dat
                 and pin_nm.startswith("GPIO")


### PR DESCRIPTION
## Summary
- Net queries (`query_net`) were missing physical pin numbers (`pin_number`) from pstchip.dat, while component queries already returned them
- Reused the same `pin_number_map` lookup logic from `query_component` in `query_net`, so both query types now consistently return physical pin numbers for Cadence/Allegro projects

## Test plan
- [ ] Query a Cadence project net that has components with pin_number_map data — verify `pin_number` field appears in pin entries
- [ ] Query a KiCad project net — verify no regression (no pin_number field expected)
- [ ] Query a component — verify pin_number still works as before