### PR TITLE
fix(schematic-analyzer): expose DNP components through indexer, netli…

### DIFF
--- a/skills/schematic-analyzer/scripts/analyzer.py
+++ b/skills/schematic-analyzer/scripts/analyzer.py
@@ -624,6 +624,7 @@ class SchematicAnalyzer:
             "ref": component.reference,
             "value": component.value,
             "mpn": mpn,
+            "dnp": bool(component.flags.get("dnp", False)),
             "page_index": page_index,
             "page_name": self._sheet_name_from_path(sheet_path),
             "properties": self._dedup_properties(component, mpn),
@@ -666,6 +667,7 @@ class SchematicAnalyzer:
             match_entry = {
                 "ref": component.reference,
                 "value": component.value,
+                "dnp": bool(component.flags.get("dnp", False)),
             }
             if mpn:
                 match_entry["mpn"] = mpn

--- a/skills/schematic-analyzer/scripts/tools/kicad/netlist_parser.py
+++ b/skills/schematic-analyzer/scripts/tools/kicad/netlist_parser.py
@@ -20,6 +20,7 @@ class NetlistComponent:
     footprint: Optional[str] = None
     pins: dict[str, str] = field(default_factory=dict)  # pin_number -> net_name
     units: list[str] = field(default_factory=list)
+    dnp: bool = False
 
 
 @dataclass
@@ -100,6 +101,13 @@ class NetlistParser:
                 if unit.get("name")
             ]
 
+            # Detect DNP from <property name="dnp"/> under <comp>
+            dnp = any(
+                (prop.get("name") or "").lower() == "dnp"
+                or (prop.findtext("name") or "").lower() == "dnp"
+                for prop in comp.findall("./property")
+            )
+
             # Pins will be populated from nets later
             components[ref] = NetlistComponent(
                 reference=ref,
@@ -109,6 +117,7 @@ class NetlistParser:
                 footprint=footprint,
                 pins={},  # Empty initially, will populate from nets
                 units=units,
+                dnp=dnp,
             )
 
         # Parse nets and populate component pins

--- a/skills/schematic-analyzer/scripts/tools/project_indexer.py
+++ b/skills/schematic-analyzer/scripts/tools/project_indexer.py
@@ -119,7 +119,7 @@ class ProjectIndexer:
         for record in self._build_sheet_records(scope):
             parser = get_schematic_parser(str(record.file_path), include_child_sheets=False)
             try:
-                local_components = parser.get_components(include_dnp=False)
+                local_components = parser.get_components(include_dnp=True)
             except TypeError:
                 local_components = parser.get_components()
             hierarchy.append(


### PR DESCRIPTION
…st parser, and CLI

Previously DNP (do-not-populate) components were silently dropped at three layers, making them invisible to users querying via kicad-cli or the CLI:

- ProjectIndexer called get_components(include_dnp=False), filtering them out
- NetlistParser ignored <property name="dnp"/> from kicad-cli-exported XML
- query_component / query_component_match responses omitted the dnp field

Now DNP components are preserved with flags["dnp"]=True, detected from netlist XML, and exposed as a boolean in CLI query responses. Downstream core_ranker still skips them via flags.get("dnp").