### PR TITLE
fix(schematic-analyzer): filter DNP components by default across quer…

### DIFF
--- a/skills/schematic-analyzer/scripts/analyzer.py
+++ b/skills/schematic-analyzer/scripts/analyzer.py
@@ -518,10 +518,14 @@ class SchematicAnalyzer:
         for candidate_index, candidate in enumerate(core_component_candidates, start=1):
             candidate["candidate_index"] = candidate_index
 
+        all_components = list(self.project_index.components.values())
+        dnp_count = sum(1 for c in all_components if c.flags.get("dnp", False))
+
         return {
             "project_overview": {
                 "project_page_count": len(page_navigation),
-                "project_component_count": len(self.project_index.components),
+                "project_component_count": len(all_components) - dnp_count,
+                "project_dnp_count": dnp_count,
                 "project_net_count": len(phase_1["nets"]),
                 "root_schematic_filename": self.scope.root_schematic.name,
                 "referenced_page_count": len(self.scope.referenced_sheets),
@@ -530,7 +534,7 @@ class SchematicAnalyzer:
             "core_component_candidates": core_component_candidates,
         }
 
-    def query_page(self, page_index: int) -> dict[str, Any]:
+    def query_page(self, page_index: int, *, include_dnp: bool = False) -> dict[str, Any]:
         """Return one page inspection payload."""
         if page_index < 1 or page_index > len(self.project_index.hierarchy):
             raise LookupError(f"Unknown page index: {page_index}")
@@ -541,6 +545,7 @@ class SchematicAnalyzer:
             self._component_summary(component)
             for component in self.project_index.components.values()
             if component.sheet_path == sheet.sheet_path
+            and (include_dnp or not component.flags.get("dnp", False))
         ]
         nets = self._page_nets(sheet.sheet_path, phase_1["component_nets"])
         return {
@@ -555,13 +560,20 @@ class SchematicAnalyzer:
             "nets": nets,
         }
 
-    def query_component(self, reference: str, *, include_full: bool = False) -> dict[str, Any]:
-        """Return one component inspection payload."""
+    def query_component(self, reference: str, *, include_full: bool = False, include_dnp: bool = False) -> dict[str, Any]:
+        """Return one component inspection payload.
+
+        Args:
+            reference: Component reference designator (e.g. "R1").
+            include_full: Include unconnected nets and full pin detail.
+            include_dnp: Allow lookup of DNP components. Default False —
+                DNP components are treated as not populated and are hidden.
+        """
         phase_1 = self._run_phase_1()
         ref = reference.upper()
         component = self.project_index.components.get(ref)
-        if component is None:
-            suggestion = self._suggest_closest_ref(ref)
+        if component is None or (not include_dnp and component.flags.get("dnp", False)):
+            suggestion = self._suggest_closest_ref(ref, include_dnp=include_dnp)
             msg = f"Component '{ref}' not found"
             if suggestion:
                 msg += f". Did you mean '{suggestion}'?"
@@ -636,9 +648,10 @@ class SchematicAnalyzer:
         }
         return payload
 
-    def query_component_match(self, text: str, *, include_all: bool = False) -> dict[str, Any]:
+    def query_component_match(self, text: str, *, include_all: bool = False, include_dnp: bool = False) -> dict[str, Any]:
         """Search components by text (supports regex)."""
         matches = []
+        dnp_filtered = 0
         # Try regex first, fallback to substring if regex is invalid
         try:
             pattern = re.compile(text, re.IGNORECASE)
@@ -662,16 +675,22 @@ class SchematicAnalyzer:
             else:
                 if wanted not in haystack.lower():
                     continue
+            if component.flags.get("dnp", False):
+                if not include_dnp:
+                    dnp_filtered += 1
+                    continue
             mpn = self._component_mpn(component)
             match_entry = {
                 "ref": component.reference,
                 "value": component.value,
             }
+            if include_dnp:
+                match_entry["dnp"] = bool(component.flags.get("dnp", False))
             if mpn:
                 match_entry["mpn"] = mpn
             matches.append(match_entry)
         shown, truncated = self._truncate_items(matches, include_all=include_all)
-        return {
+        result = {
             "query_type": "component",
             "search": text,
             "matches": shown,
@@ -679,6 +698,9 @@ class SchematicAnalyzer:
             "shown": len(shown),
             "total": len(matches),
         }
+        if dnp_filtered:
+            result["dnp_filtered"] = dnp_filtered
+        return result
 
     def query_net(self, net_name: str) -> dict[str, Any]:
         """Return one exact-net inspection payload."""
@@ -1311,13 +1333,16 @@ class SchematicAnalyzer:
 
         return 1
 
-    def _suggest_closest_ref(self, ref: str) -> str | None:
+    def _suggest_closest_ref(self, ref: str, *, include_dnp: bool = False) -> str | None:
         """Find closest component reference by prefix match."""
         prefix = re.match(r"^[A-Z]+", ref)
         if not prefix:
             return None
         pfx = prefix.group()
-        candidates = [r for r in self.project_index.components if r.startswith(pfx)]
+        candidates = [
+            r for r, comp in self.project_index.components.items()
+            if r.startswith(pfx) and (include_dnp or not comp.flags.get("dnp", False))
+        ]
         if not candidates:
             return None
         # Sort by numeric suffix distance

--- a/skills/schematic-analyzer/scripts/cli_commands.py
+++ b/skills/schematic-analyzer/scripts/cli_commands.py
@@ -35,15 +35,16 @@ def cmd_query(args):
 
     analyzer = build_analyzer(schematic_path, args)
     try:
+        include_dnp = getattr(args, "include_dnp", False)
         if args.page is not None:
-            payload = analyzer.query_page(args.page)
+            payload = analyzer.query_page(args.page, include_dnp=include_dnp)
         elif args.component is not None:
             if args.match:
-                payload = analyzer.query_component_match(args.match, include_all=args.all)
+                payload = analyzer.query_component_match(args.match, include_all=args.all, include_dnp=include_dnp)
             elif not args.component:
                 raise ValueError("--component requires a reference unless used with --match")
             else:
-                payload = analyzer.query_component(args.component, include_full=args.full)
+                payload = analyzer.query_component(args.component, include_full=args.full, include_dnp=include_dnp)
         elif args.net is not None:
             if args.match:
                 payload = analyzer.query_net_match(args.match, include_all=args.all)

--- a/skills/schematic-analyzer/scripts/cli_parser.py
+++ b/skills/schematic-analyzer/scripts/cli_parser.py
@@ -32,6 +32,8 @@ def build_parser() -> argparse.ArgumentParser:
     query_parser.add_argument("--match", help="Search text for component or net query mode")
     query_parser.add_argument("--all", action="store_true", help="Reserved full-result mode")
     query_parser.add_argument("--full", action="store_true", help="Return full component pin-net details")
+    query_parser.add_argument("--include-dnp", action="store_true",
+                              help="Include DNP (do-not-populate) components. Default: filtered out.")
     query_parser.add_argument("--output", "-o", help="Write JSON result to file")
     query_parser.set_defaults(func=cmd_query)
 

--- a/skills/schematic-analyzer/scripts/cli_support.py
+++ b/skills/schematic-analyzer/scripts/cli_support.py
@@ -38,6 +38,9 @@ def print_overview_summary(payload: dict) -> None:
     print("Project Overview")
     print(f"Project Pages: {project['project_page_count']}")
     print(f"Project Components: {project['project_component_count']}")
+    dnp = project.get("project_dnp_count")
+    if dnp:
+        print(f"Project DNP (filtered): {dnp}")
     print(f"Project Nets: {project['project_net_count']}")
     print(f"Root Schematic: {project['root_schematic_filename']}")
     print(f"Referenced Pages: {project['referenced_page_count']}")

--- a/skills/schematic-analyzer/scripts/tools/kicad/schematic_parser.py
+++ b/skills/schematic-analyzer/scripts/tools/kicad/schematic_parser.py
@@ -746,14 +746,22 @@ class SchematicParser:
 
         return deduped
 
-    def get_components(self) -> list[SchematicComponent]:
+    def get_components(self, include_dnp: bool = False) -> list[SchematicComponent]:
         """Get all components from schematic.
+
+        Args:
+            include_dnp: If True, include DNP (do-not-populate) components.
+                Default False — DNP components are filtered out to match
+                the populated board, not the schematic drawing.
 
         Returns:
             List of components
         """
         data = self._parse_file()
-        return [SchematicComponent.from_kicad_skip(c) for c in data["components"]]
+        components = [SchematicComponent.from_kicad_skip(c) for c in data["components"]]
+        if include_dnp:
+            return components
+        return [c for c in components if not c.flags.get("dnp", False)]
 
     def get_nets(self) -> list[SchematicNet]:
         """Get all nets from schematic.

--- a/skills/schematic-analyzer/scripts/tools/project_indexer.py
+++ b/skills/schematic-analyzer/scripts/tools/project_indexer.py
@@ -118,10 +118,9 @@ class ProjectIndexer:
 
         for record in self._build_sheet_records(scope):
             parser = get_schematic_parser(str(record.file_path), include_child_sheets=False)
-            try:
-                local_components = parser.get_components(include_dnp=False)
-            except TypeError:
-                local_components = parser.get_components()
+            # Keep DNP components in the index (flagged) — filtering happens at
+            # the query layer so include_dnp queries can still surface them.
+            local_components = parser.get_components(include_dnp=True)
             hierarchy.append(
                 SheetInfo(
                     sheet_name=record.sheet_name,


### PR DESCRIPTION
…y surfaces

DNP (do-not-populate) components represent optional positions not fitted on the board. Analysis should reflect the populated board, not the schematic drawing — so DNP is now filtered by default at every query surface, with --include-dnp as the explicit opt-in.

Changes:
- KiCad SchematicParser.get_components() now accepts include_dnp=False (parity with Cadence parser); filters via flags["dnp"]
- ProjectIndexer no longer needs try/except fallback — both parsers support the include_dnp parameter. DNP components remain in the index (flagged) so opt-in queries can still surface them
- SchematicAnalyzer.query_component / query_page / query_component_match / _suggest_closest_ref all gain include_dnp parameter (default False)
- query_component_match reports dnp_filtered count when DNP is excluded
- build_overview exposes project_dnp_count alongside the populated count
- CLI gains --include-dnp flag; overview summary prints "DNP (filtered)" line so users can see how many were excluded

Verified on Wio Tracker L2 DVT (504 components, 50 DNP):
- Default overview: 454 components + "DNP (filtered): 50"
- query --component R159 returns not_found (populated view)
- query --component R159 --include-dnp returns the component