### PR TITLE
fix(schematic-analyzer): filter DNP at parser boundary, hide from dow…

### DIFF
--- a/skills/schematic-analyzer/scripts/analyzer.py
+++ b/skills/schematic-analyzer/scripts/analyzer.py
@@ -522,6 +522,7 @@ class SchematicAnalyzer:
             "project_overview": {
                 "project_page_count": len(page_navigation),
                 "project_component_count": len(self.project_index.components),
+                "project_dnp_count": self.project_index.statistics.dnp_filtered,
                 "project_net_count": len(phase_1["nets"]),
                 "root_schematic_filename": self.scope.root_schematic.name,
                 "referenced_page_count": len(self.scope.referenced_sheets),

--- a/skills/schematic-analyzer/scripts/cli_support.py
+++ b/skills/schematic-analyzer/scripts/cli_support.py
@@ -38,6 +38,9 @@ def print_overview_summary(payload: dict) -> None:
     print("Project Overview")
     print(f"Project Pages: {project['project_page_count']}")
     print(f"Project Components: {project['project_component_count']}")
+    dnp = project.get("project_dnp_count")
+    if dnp:
+        print(f"Project DNP (filtered): {dnp}")
     print(f"Project Nets: {project['project_net_count']}")
     print(f"Root Schematic: {project['root_schematic_filename']}")
     print(f"Referenced Pages: {project['referenced_page_count']}")

--- a/skills/schematic-analyzer/scripts/tools/cadence/xml_parser.py
+++ b/skills/schematic-analyzer/scripts/tools/cadence/xml_parser.py
@@ -809,20 +809,8 @@ class CadenceXMLParser:
             "exclude_from_sim": dnp,
         }
 
-    def _filter_dnp(
-        self, components: list[SchematicComponent], include_dnp: bool = False,
-    ) -> list[SchematicComponent]:
-        """Filter DNP components from a list.
-
-        Args:
-            components: Component list to filter.
-            include_dnp: If True, return all components including DNP.
-
-        Returns:
-            Filtered component list.
-        """
-        if include_dnp:
-            return list(components)
+    def _filter_dnp(self, components: list[SchematicComponent]) -> list[SchematicComponent]:
+        """Return only populated components (DNP excluded)."""
         return [c for c in components if not c.flags.get("dnp", False)]
 
     def _build_components(self) -> None:
@@ -974,14 +962,19 @@ class CadenceXMLParser:
 
     # ---- Public interface (matches KiCad SchematicParser) ----
 
-    def get_components(self, include_dnp: bool = False) -> list[SchematicComponent]:
-        """Get components from the schematic.
+    def get_components(self) -> list[SchematicComponent]:
+        """Return populated components only.
 
-        Args:
-            include_dnp: If True, include DNP (do-not-populate) components.
+        DNP components are filtered out so downstream analysis reflects the
+        populated board. Use get_dnp_count() to report how many were excluded.
         """
         self._ensure_parsed()
-        return self._filter_dnp(self._components, include_dnp)
+        return self._filter_dnp(self._components)
+
+    def get_dnp_count(self) -> int:
+        """Return the number of DNP components excluded by get_components()."""
+        self._ensure_parsed()
+        return sum(1 for c in self._components if c.flags.get("dnp", False))
 
     def get_nets(self) -> list[SchematicNet]:
         """Get all nets from the schematic."""
@@ -1030,13 +1023,8 @@ class CadenceXMLParser:
                 return comp
         return None
 
-    def search_components(self, pattern: str, include_dnp: bool = False) -> list[SchematicComponent]:
-        """Search components by text pattern (matches reference, value, properties).
-
-        Args:
-            pattern: Search pattern (case-insensitive).
-            include_dnp: If True, include DNP components in results.
-        """
+    def search_components(self, pattern: str) -> list[SchematicComponent]:
+        """Search populated components by text pattern (matches reference, value, properties)."""
         self._ensure_parsed()
         pattern_lower = pattern.lower()
         results = []
@@ -1045,7 +1033,7 @@ class CadenceXMLParser:
                     pattern_lower in comp.value.lower() or
                     any(pattern_lower in v.lower() for v in comp.properties.values())):
                 results.append(comp)
-        return self._filter_dnp(results, include_dnp)
+        return self._filter_dnp(results)
 
     def get_component_connections(self, reference: str) -> dict[str, Any]:
         """Get pin-to-net connections for a component."""
@@ -1120,17 +1108,12 @@ class CadenceXMLParser:
         self._ensure_parsed()
         return [p["name"] for p in self._pages]
 
-    def get_components_on_page(self, page_index: int, include_dnp: bool = False) -> list[SchematicComponent]:
-        """Get components on a specific page.
-
-        Args:
-            page_index: Zero-based page index.
-            include_dnp: If True, include DNP components.
-        """
+    def get_components_on_page(self, page_index: int) -> list[SchematicComponent]:
+        """Get populated components on a specific page."""
         self._ensure_parsed()
         page_refs = set()
         for part in self._parts:
             if part.page_index == page_index:
                 page_refs.add(part.reference.upper())
         page_components = [c for c in self._components if c.reference.upper() in page_refs]
-        return self._filter_dnp(page_components, include_dnp)
+        return self._filter_dnp(page_components)

--- a/skills/schematic-analyzer/scripts/tools/kicad/schematic_parser.py
+++ b/skills/schematic-analyzer/scripts/tools/kicad/schematic_parser.py
@@ -747,13 +747,23 @@ class SchematicParser:
         return deduped
 
     def get_components(self) -> list[SchematicComponent]:
-        """Get all components from schematic.
+        """Return populated components only.
 
-        Returns:
-            List of components
+        DNP (do-not-populate) components are filtered out so downstream
+        analysis reflects the populated board, not the schematic drawing.
+        Use get_dnp_count() to report how many were excluded.
         """
         data = self._parse_file()
-        return [SchematicComponent.from_kicad_skip(c) for c in data["components"]]
+        components = [SchematicComponent.from_kicad_skip(c) for c in data["components"]]
+        return [c for c in components if not c.flags.get("dnp", False)]
+
+    def get_dnp_count(self) -> int:
+        """Return the number of DNP components excluded by get_components()."""
+        data = self._parse_file()
+        return sum(
+            1 for c in data["components"]
+            if c.get("flags", {}).get("dnp", False)
+        )
 
     def get_nets(self) -> list[SchematicNet]:
         """Get all nets from schematic.

--- a/skills/schematic-analyzer/scripts/tools/project_indexer.py
+++ b/skills/schematic-analyzer/scripts/tools/project_indexer.py
@@ -58,6 +58,7 @@ class IndexStatistics:
     total_components: int
     total_sheets: int
     duplicate_reference_count: int
+    dnp_filtered: int = 0
 
 
 @dataclass
@@ -115,13 +116,12 @@ class ProjectIndexer:
         components: dict[str, ComponentInstance] = {}
         hierarchy: list[SheetInfo] = []
         sheet_name_to_path: dict[str, str] = {}
+        dnp_filtered = 0
 
         for record in self._build_sheet_records(scope):
             parser = get_schematic_parser(str(record.file_path), include_child_sheets=False)
-            try:
-                local_components = parser.get_components(include_dnp=False)
-            except TypeError:
-                local_components = parser.get_components()
+            local_components = parser.get_components()
+            dnp_filtered += parser.get_dnp_count()
             hierarchy.append(
                 SheetInfo(
                     sheet_name=record.sheet_name,
@@ -180,6 +180,7 @@ class ProjectIndexer:
                 total_components=len(components),
                 total_sheets=len(hierarchy),
                 duplicate_reference_count=0,  # TODO: compute from actual instance resolution
+                dnp_filtered=dnp_filtered,
             ),
         )
 


### PR DESCRIPTION
…nstream

DNP (do-not-populate) components represent optional positions not fitted on the board. Per reviewer feedback, filtering is now consolidated at the parser boundary so downstream code (ProjectIndexer, SchematicAnalyzer, queries) never sees DNP and doesn't need to know about it.

Parser contract (both KiCad and Cadence):
- get_components() -> populated only, no parameters
- get_dnp_count() -> count of excluded DNP, for stats/reporting only

ProjectIndexer:
- Calls parser.get_components() directly — no try/except fallback, no include_dnp parameter
- IndexStatistics gains dnp_filtered field, populated per-sheet from parser.get_dnp_count()

SchematicAnalyzer:
- query_component / query_page / query_component_match / _suggest_closest_ref reverted to their original shape — no DNP knowledge
- build_overview reads dnp_filtered from statistics instead of inspecting component flags

Cadence parser:
- _filter_dnp(components) helper simplified (no include_dnp param)
- get_components / search_components / get_components_on_page all drop the include_dnp parameter

No opt-in anywhere: DNP is either in the analysis or it isn't. Users wanting the schematic-drawing view can grep the source file directly.

Verified on Wio Tracker L2 DVT (504 total, 50 DNP):
- Overview: 454 components + "DNP (filtered): 50"
- query --component R159 -> not_found
- query --component --match "." --all -> 454 populated